### PR TITLE
Improve cross-platform cloning robustness

### DIFF
--- a/src/carve/sig_scan.c
+++ b/src/carve/sig_scan.c
@@ -1,3 +1,7 @@
+#if !defined(_WIN32)
+#define _XOPEN_SOURCE 700
+#endif
+
 #include "tigre.h"
 #include <string.h>
 #include <stdio.h>
@@ -83,6 +87,7 @@ static int pread_chunk(int fd, void *buf, size_t n, uint64_t off){
 }
 #else
 #  include <unistd.h>
+#  include <sys/types.h>
 static int pread_chunk(int fd, void *buf, size_t n, uint64_t off){
     size_t got=0;
     while (got<n){

--- a/src/carve/tiff_ifd.c
+++ b/src/carve/tiff_ifd.c
@@ -1,3 +1,7 @@
+#if !defined(_WIN32)
+#define _XOPEN_SOURCE 700
+#endif
+
 #include "tigre.h"
 #include <stdlib.h>
 #include <string.h>

--- a/src/core/engine.c
+++ b/src/core/engine.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include <unistd.h>     // pread()
 #include <fcntl.h>
 #include <sys/types.h>
@@ -19,6 +20,59 @@
 #endif
 
 static int pread_some(int fd, void *buf, size_t n, uint64_t off);
+static int ensure_directory(const char *path);
+
+#if defined(_WIN32)
+static int make_dir_single(const char *path){
+    if (!path || !*path) return 0;
+    if (_mkdir(path)==0) return 0;
+    if (errno==EEXIST) return 0;
+    return -1;
+}
+#else
+static int make_dir_single(const char *path){
+    if (!path || !*path) return 0;
+    if (mkdir(path, 0755)==0) return 0;
+    if (errno==EEXIST) return 0;
+    return -1;
+}
+#endif
+
+static int ensure_directory(const char *path){
+    if (!path || !*path) return 0;
+    char tmp[1024];
+    size_t len = strlen(path);
+    if (len >= sizeof(tmp)){ errno = ENAMETOOLONG; return -1; }
+    memcpy(tmp, path, len+1);
+
+    size_t start = 0;
+#if defined(_WIN32)
+    if (len >= 2 && tmp[1]==':') start = 2; // skip drive letter
+#endif
+    for (size_t i=start;i<len;i++){
+        if (tmp[i]=='/' || tmp[i]=='\\'){
+            char saved = tmp[i];
+            tmp[i] = '\0';
+            size_t sub_len = strlen(tmp);
+#if defined(_WIN32)
+            if (!(sub_len==2 && tmp[1]==':'))
+#endif
+            {
+                if (sub_len>0 && strcmp(tmp,".")!=0 && strcmp(tmp,"..")!=0){
+                    if (make_dir_single(tmp)!=0 && errno!=EEXIST) return -1;
+                }
+            }
+            tmp[i] = saved;
+        }
+    }
+    if (len>0 && strcmp(tmp,".")!=0 && strcmp(tmp,"..")!=0){
+#if defined(_WIN32)
+        if (len==2 && tmp[1]==':') return 0;
+#endif
+        if (make_dir_single(tmp)!=0 && errno!=EEXIST) return -1;
+    }
+    return 0;
+}
 
 extern double tig_score_deflate(const unsigned char*, size_t);
 extern double tig_score_lzw(const unsigned char*, size_t);
@@ -39,6 +93,7 @@ tig_extract_result tig_extract(int fd, const tig_tiff_header *h,
                                const tig_tiff_ifd *v, const char *out_dir, const char *stem)
 {
     tig_extract_result R={0};
+    (void)h;
     char base[1024];
     snprintf(base,sizeof(base), "%s/%s", out_dir, stem);
 
@@ -115,11 +170,10 @@ int tig_engine_scan_recover(const char *img_path, const char *out_dir,
                             uint64_t max_hits, int vlevel)
 {
     (void)prefer_free_space; (void)fs_list_csv; (void)vlevel;
-#if defined(_WIN32)
-    _mkdir(out_dir);
-#else
-    char cmd[1024]; snprintf(cmd,sizeof(cmd),"mkdir -p \"%s\"", out_dir); system(cmd);
-#endif
+    if (ensure_directory(out_dir)!=0){
+        LOGE("çıktı dizini oluşturulamadı: %s (%s)", out_dir, strerror(errno));
+        return 1;
+    }
 
     int fd = tig_open_ro(img_path);
     if (fd<0){ LOGE("imaj açılamadı: %s", img_path); return 1; }
@@ -158,11 +212,10 @@ int tig_engine_dig_range(const char *img_path, tig_range range,
                          const char *out_dir, const char *heur_csv, int vlevel)
 {
     (void)heur_csv; (void)vlevel;
-#if defined(_WIN32)
-    _mkdir(out_dir);
-#else
-    char cmd[1024]; snprintf(cmd,sizeof(cmd),"mkdir -p \"%s\"", out_dir); system(cmd);
-#endif
+    if (ensure_directory(out_dir)!=0){
+        LOGE("çıktı dizini oluşturulamadı: %s (%s)", out_dir, strerror(errno));
+        return 1;
+    }
     int fd = tig_open_ro(img_path);
     if (fd<0){ LOGE("imaj açılamadı: %s", img_path); return 1; }
 

--- a/src/io/clone_img.c
+++ b/src/io/clone_img.c
@@ -1,3 +1,7 @@
+#if !defined(_WIN32)
+#define _XOPEN_SOURCE 700
+#endif
+
 #include "tigre.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -27,45 +31,60 @@ static int open_out(const char* p){
     int fd = _open(p, _O_CREAT|_O_TRUNC|_O_WRONLY|_O_BINARY, _S_IREAD|_S_IWRITE);
     return fd<0?-1:fd;
 }
-static int64_t filesize(int fd) __attribute__((unused));
-static int64_t filesize(int fd){
-    __int64 s = _lseeki64(fd, 0, SEEK_END);
-    _lseeki64(fd, 0, SEEK_SET);
-    return s;
+static int write_full(int fd, const void *buf, size_t n){
+    size_t done = 0;
+    while (done < n){
+        int w = _write(fd, (const char*)buf + done, (unsigned)(n - done));
+        if (w <= 0) return -1;
+        done += (size_t)w;
+    }
+    return 0;
 }
 #else
 #  include <sys/stat.h>
+#  include <sys/types.h>
 #  include <fcntl.h>
 #  include <unistd.h>
 static int open_out(const char* p){
     int fd = open(p, O_CREAT|O_TRUNC|O_WRONLY, 0644);
     return fd<0?-1:fd;
 }
-static off_t filesize_fd(int fd){
-    off_t cur = lseek(fd, 0, SEEK_CUR);
-    off_t end = lseek(fd, 0, SEEK_END);
-    lseek(fd, cur, SEEK_SET);
-    return end;
+static int write_full(int fd, const void *buf, size_t n){
+    size_t done = 0;
+    while (done < n){
+        ssize_t w = write(fd, (const char*)buf + done, n - done);
+        if (w < 0){
+            if (errno == EINTR) continue;
+            return -1;
+        }
+        if (w == 0) return -1;
+        done += (size_t)w;
+    }
+    return 0;
 }
 #endif
 
-static int pread_all(int fd, void *buf, size_t n, uint64_t off){
+static int pread_all(int fd, void *buf, size_t n, uint64_t off, size_t *out_got){
 #if defined(_WIN32)
     if (_lseeki64(fd, off, SEEK_SET) < 0) return -1;
     size_t got=0;
     while (got<n){
         int r = _read(fd, (char*)buf+got, (unsigned)(n-got));
-        if (r<=0) return -2;
+        if (r<0) return -2;
+        if (r==0) break;
         got += (size_t)r;
     }
+    if (out_got) *out_got = got;
     return 0;
 #else
     size_t got=0;
     while (got<n){
         ssize_t r = pread(fd, (char*)buf+got, n-got, (off_t)off+got);
-        if (r<=0) return -2;
+        if (r<0) return -2;
+        if (r==0) break;
         got += (size_t)r;
     }
+    if (out_got) *out_got = got;
     return 0;
 #endif
 }
@@ -86,28 +105,42 @@ int tig_clone_to_img(const char *src_dev, const char *dst_img,
 
     uint64_t off=0; uint64_t copied=0; int err=0;
     FILE *map = NULL;
-    if (map_json && *map_json) map = fopen(map_json,"w"), fprintf(map,"[\n");
+    int map_has_entry = 0;
+    if (map_json && *map_json){
+        map = fopen(map_json,"w");
+        if (map){
+            fprintf(map,"[\n");
+        } else {
+            fprintf(stderr,"[clone] map dosyası açılamadı: %s\n", map_json);
+        }
+    }
     const uint64_t progress_interval = 100; // report every 100 blocks
 
     while (1){
-        int r = pread_all(sfd, buf, BS, off);
-    if (r!=0){
+        size_t got = 0;
+        int r = pread_all(sfd, buf, BS, off, &got);
+        if (r!=0){
             int ok=0;
             for (int t=0;t<retry;t++){
-                r = pread_all(sfd, buf, BS, off);
+                r = pread_all(sfd, buf, BS, off, &got);
                 if (r==0){ ok=1; break; }
             }
             if (!ok){
                 if (skip_on_error){
                     // delik: hedefte sıfır yaz
                     void *zb = calloc(1, BS);
-#if defined(_WIN32)
-                    _write(dfd, zb, (unsigned)BS);
-#else
-                    write(dfd, zb, BS);
-#endif
-                    if (map) fprintf(map,"  {\"off\": %llu, \"len\": %zu, \"status\": \"hole\"},\n",
-                                     (unsigned long long)off, BS);
+                    if (write_full(dfd, zb, BS)!=0){
+                        fprintf(stderr,"[clone] yazma hatası: %s\n", strerror(errno));
+                        free(zb);
+                        err=5;
+                        break;
+                    }
+                    if (map){
+                        if (map_has_entry) fprintf(map,",\n");
+                        fprintf(map,"  {\"off\": %llu, \"len\": %zu, \"status\": \"hole\"}",
+                                (unsigned long long)off, BS);
+                        map_has_entry = 1;
+                    }
                     free(zb);
                     off += BS; copied += BS;
                     if ((copied/BS) % progress_interval == 0){
@@ -120,44 +153,83 @@ int tig_clone_to_img(const char *src_dev, const char *dst_img,
                 }
             }
         }
-    // başarı: bloğu yaz
+        if (got==0){
+            // EOF reached cleanly
+            break;
+        }
+        size_t to_write = got;
+        // başarı: bloğu yaz
 #if defined(_WIN32)
-    _write(dfd, buf, (unsigned)BS);
+        if (write_full(dfd, buf, to_write)!=0){
+            fprintf(stderr,"[clone] yazma hatası: %s\n", strerror(errno));
+            err=5; break;
+        }
 #else
-    // If the block is entirely zero, create a sparse hole by seeking instead of writing
-    int all_zero = 1;
-    for (size_t zi = 0; zi < BS; zi++){
-        if (((unsigned char*)buf)[zi] != 0){ all_zero = 0; break; }
-    }
-    if (all_zero){
-        off_t cur = lseek(dfd, 0, SEEK_CUR);
-        if (cur == (off_t)-1){
-        // lseek not supported on this fd? fallback to writing
-        write(dfd, buf, BS);
+        // If the block is entirely zero, create a sparse hole by seeking instead of writing
+        int all_zero = 1;
+        for (size_t zi = 0; zi < to_write; zi++){
+            if (((unsigned char*)buf)[zi] != 0){ all_zero = 0; break; }
+        }
+        if (all_zero){
+            off_t cur = lseek(dfd, 0, SEEK_CUR);
+            if (cur == (off_t)-1){
+                // lseek not supported on this fd? fallback to writing
+                if (write_full(dfd, buf, to_write)!=0){
+                    fprintf(stderr,"[clone] yazma hatası: %s\n", strerror(errno));
+                    err=5; break;
+                }
+            } else {
+                // advance file pointer creating a hole
+                if (lseek(dfd, (off_t)to_write, SEEK_CUR) == (off_t)-1){
+                    // if seek fails, fallback to writing
+                    if (write_full(dfd, buf, to_write)!=0){
+                        fprintf(stderr,"[clone] yazma hatası: %s\n", strerror(errno));
+                        err=5; break;
+                    }
+                }
+            }
+            if (map){
+                if (map_has_entry) fprintf(map,",\n");
+                fprintf(map,"  {\"off\": %llu, \"len\": %zu, \"status\": \"hole\"}",
+                        (unsigned long long)off, to_write);
+                map_has_entry = 1;
+            }
         } else {
-        // advance file pointer creating a hole
-        if (lseek(dfd, BS, SEEK_CUR) == (off_t)-1){
-            // if seek fails, fallback to writing
-            write(dfd, buf, BS);
+            if (write_full(dfd, buf, to_write)!=0){
+                fprintf(stderr,"[clone] yazma hatası: %s\n", strerror(errno));
+                err=5; break;
+            }
+            if (map){
+                if (map_has_entry) fprintf(map,",\n");
+                fprintf(map,"  {\"off\": %llu, \"len\": %zu, \"status\": \"ok\"}",
+                        (unsigned long long)off, to_write);
+                map_has_entry = 1;
+            }
         }
-        }
-        if (map) fprintf(map,"  {\"off\": %llu, \"len\": %zu, \"status\": \"hole\"},\n",
-                 (unsigned long long)off, BS);
-    } else {
-        write(dfd, buf, BS);
-        if (map) fprintf(map,"  {\"off\": %llu, \"len\": %zu, \"status\": \"ok\"},\n",
-                 (unsigned long long)off, BS);
-    }
 #endif
-    off += BS; copied += BS;
+        off += to_write; copied += to_write;
+
+        if (copied >= BS && (copied/BS) % progress_interval == 0){
+            fprintf(stderr,"[clone] copied %llu blocks (%llu bytes)\n",
+                    (unsigned long long)(copied/BS), (unsigned long long)copied);
+        }
 
         // burada sonsuz akışı durdurmak için bir üst sınır yoksa read hata verene kadar gider.
         // tipik kullanımda kaynak “file” ise boyutu bilinir; device ise kullanıcı range verir.
         // basit strateji: 4TB gibi bir üst sınır parametreleştirilebilir. Burada atlanıyor.
         if (copied > (1ull<<46)) { fprintf(stderr,"[clone] güvenlik sınırı aşıldı, duruyor\n"); break; }
+
+        if (got < BS){
+            // final partial chunk processed
+            break;
+        }
     }
 
-    if (map){ fseek(map, -2, SEEK_END); fprintf(map,"\n]\n"); fclose(map); }
+    if (map){
+        if (map_has_entry) fprintf(map,"\n");
+        fprintf(map,"]\n");
+        fclose(map);
+    }
     tig_close(sfd);
 #if defined(_WIN32)
     _close(dfd);

--- a/src/io/dev_ro.c
+++ b/src/io/dev_ro.c
@@ -15,6 +15,10 @@ void tig_close(int fd){ _close(fd); }
 #else
 #  include <fcntl.h>
 #  include <unistd.h>
+#  include <sys/types.h>
+#  ifndef O_CLOEXEC
+#    define O_CLOEXEC 0
+#  endif
 int tig_open_ro(const char *path){
     int fd = open(path, O_RDONLY | O_CLOEXEC);
     return fd;


### PR DESCRIPTION
## Summary
- ensure platform-neutral directory creation and clone I/O helpers behave on Windows, macOS, and Linux
- harden the cloning loop to support partial reads, sparse holes, and robust map.json generation
- enable portable use of pread/pwrite-style helpers across modules by advertising _XOPEN_SOURCE and guarding O_CLOEXEC

## Testing
- make -f Makefile.linux

------
https://chatgpt.com/codex/tasks/task_e_68d30f56604c8330890c6621fc655898