### PR TITLE
Add fragment management and validation pipeline

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -8,6 +8,8 @@ SOURCES := \
   src/cli/tig_cli.c \
   src/core/engine.c \
   src/core/report.c \
+  src/core/fragment.c \
+  src/core/validator.c \
   src/core/log.c \
   src/carve/sig_scan.c \
   src/carve/tiff_ifd.c \

--- a/Makefile.mac
+++ b/Makefile.mac
@@ -10,6 +10,8 @@ SOURCES  := \
   src/cli/tig_cli.c \
   src/core/engine.c \
   src/core/report.c \
+  src/core/fragment.c \
+  src/core/validator.c \
   src/core/log.c \
   src/carve/sig_scan.c \
   src/carve/tiff_ifd.c \

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -8,6 +8,8 @@ SOURCES := \
   src/cli/tig_cli.c \
   src/core/engine.c \
   src/core/report.c \
+  src/core/fragment.c \
+  src/core/validator.c \
   src/core/log.c \
   src/carve/sig_scan.c \
   src/carve/tiff_ifd.c \

--- a/include/tigre.h
+++ b/include/tigre.h
@@ -47,12 +47,58 @@ typedef struct {
     uint32_t missing_parts;
     double   score_stream;     // 0..1 (Deflate/LZW checks)
     double   score_texture;    // 0..1 (V3 texture continuity)
+    double   confidence;       // 0..1 birleşik güven puanı
 } tig_extract_result;
 
 typedef struct {
     uint64_t start_lba;
     uint64_t end_lba;
 } tig_range;
+
+typedef struct {
+    uint64_t offset;
+    uint64_t length;
+    uint16_t compression;
+    uint64_t hash64;
+    double   entropy;
+    double   header_score;
+    double   stream_score;
+    double   texture_score;
+    unsigned char *capture;
+    size_t   capture_len;
+} tig_fragment_entry;
+
+typedef struct {
+    tig_fragment_entry *items;
+    size_t count;
+    size_t capacity;
+    size_t capture_limit;
+} tig_fragment_pool;
+
+typedef struct {
+    uint64_t offset;
+    uint64_t length;
+    uint16_t compression;
+    uint64_t hash64;
+    double   entropy;
+    double   header_score;
+    double   stream_score;
+    double   texture_score;
+    const unsigned char *data;
+    size_t   data_len;
+    double   match_score;
+} tig_fragment_match;
+
+typedef struct {
+    double   stream_avg;
+    double   texture_avg;
+    double   entropy_avg;
+    double   coverage_ratio;
+    uint32_t segments_indexed;
+    uint32_t missing_parts;
+    double   confidence;
+    int      coverage_ok;
+} tig_validation_summary;
 
 // io
 int  tig_open_ro(const char *path); // returns fd >=0
@@ -73,7 +119,30 @@ void tig_free_ifd(tig_tiff_ifd *v);
 // extraction (dump + optional rebuild)
 tig_extract_result tig_extract(int fd, const tig_tiff_header *hdr,
                                const tig_tiff_ifd *ifd,
-                               const char *out_dir, const char *stem);
+                               const char *out_dir, const char *stem,
+                               tig_fragment_pool *pool_out,
+                               tig_validation_summary *summary_out);
+
+// fragment yönetimi
+int  tig_fragment_pool_init(tig_fragment_pool *pool, size_t capacity_hint, size_t capture_limit);
+void tig_fragment_pool_reset(tig_fragment_pool *pool);
+void tig_fragment_pool_free(tig_fragment_pool *pool);
+int  tig_fragment_pool_ingest(tig_fragment_pool *pool, uint64_t offset,
+                              const unsigned char *buf, size_t len,
+                              uint16_t compression, double stream_score,
+                              double texture_score);
+int  tig_fragment_pool_find_candidate(const tig_fragment_pool *pool,
+                                      uint64_t desired_len, uint16_t compression,
+                                      double tolerance, tig_fragment_match *out);
+
+// doğrulama
+int  tig_validation_summarize(const tig_tiff_ifd *ifd,
+                              const tig_fragment_pool *pool,
+                              const double *stream_scores,
+                              const double *texture_scores,
+                              uint64_t count,
+                              uint32_t missing_parts,
+                              tig_validation_summary *out_summary);
 
 // write minimal TIFF (uncompressed single-strip)
 int tig_write_simple_tiff_uncompressed(const char *path,
@@ -92,7 +161,9 @@ int tig_engine_dig_range(const char *img_path, tig_range range,
 // reports
 int tig_write_report(const char *dir, const char *stem,
                      const tig_tiff_header *h, const tig_tiff_ifd *v,
-                     const tig_extract_result *r);
+                     const tig_extract_result *r,
+                     const tig_fragment_pool *pool,
+                     const tig_validation_summary *summary);
 
 #ifdef __cplusplus
 }

--- a/src/core/engine.c
+++ b/src/core/engine.c
@@ -21,6 +21,9 @@
 
 static int pread_some(int fd, void *buf, size_t n, uint64_t off);
 static int ensure_directory(const char *path);
+static void build_with_suffix(char *dst, size_t dst_sz, const char *base, const char *suffix);
+static void build_part_filename(char *dst, size_t dst_sz, const char *base, unsigned long long idx);
+static size_t tig_strnlen(const char *s, size_t max_len);
 
 #if defined(_WIN32)
 static int make_dir_single(const char *path){
@@ -74,6 +77,44 @@ static int ensure_directory(const char *path){
     return 0;
 }
 
+static size_t tig_strnlen(const char *s, size_t max_len){
+    size_t i = 0;
+    if (!s) return 0;
+    for (; i<max_len && s[i]; i++);
+    return i;
+}
+
+static void build_with_suffix(char *dst, size_t dst_sz, const char *base, const char *suffix){
+    if (!dst || dst_sz==0) return;
+    size_t base_len = tig_strnlen(base, dst_sz-1);
+    if (base_len > dst_sz-1) base_len = dst_sz-1;
+    memcpy(dst, base, base_len);
+    size_t remain = dst_sz - base_len;
+    if (remain == 0){ dst[dst_sz-1] = '\0'; return; }
+    size_t suf_len = strlen(suffix ? suffix : "");
+    if (suf_len >= remain) suf_len = remain-1;
+    memcpy(dst + base_len, suffix, suf_len);
+    dst[base_len + suf_len] = '\0';
+}
+
+static void build_part_filename(char *dst, size_t dst_sz, const char *base, unsigned long long idx){
+    if (!dst || dst_sz==0) return;
+    size_t base_len = tig_strnlen(base, dst_sz-1);
+    const size_t suffix_reserve = 20; // _part_0000.bin
+    if (base_len > dst_sz-1) base_len = dst_sz-1;
+    if (base_len + suffix_reserve >= dst_sz){
+        if (dst_sz > suffix_reserve)
+            base_len = dst_sz - suffix_reserve - 1;
+        else
+            base_len = 0;
+    }
+    memcpy(dst, base, base_len);
+    int w = snprintf(dst + base_len, dst_sz - base_len, "_part_%04llu.bin", idx);
+    if (w < 0 || (size_t)w >= dst_sz - base_len){
+        dst[dst_sz-1] = '\0';
+    }
+}
+
 extern double tig_score_deflate(const unsigned char*, size_t);
 extern double tig_score_lzw(const unsigned char*, size_t);
 extern double tig_score_packbits(const unsigned char*, size_t);
@@ -90,12 +131,27 @@ static int is_contiguous(const tig_tiff_ifd *v){
 }
 
 tig_extract_result tig_extract(int fd, const tig_tiff_header *h,
-                               const tig_tiff_ifd *v, const char *out_dir, const char *stem)
+                               const tig_tiff_ifd *v, const char *out_dir, const char *stem,
+                               tig_fragment_pool *pool_out,
+                               tig_validation_summary *summary_out)
 {
     tig_extract_result R={0};
     (void)h;
     char base[1024];
     snprintf(base,sizeof(base), "%s/%s", out_dir, stem);
+
+    tig_fragment_pool pool_local;
+    tig_fragment_pool *pool_ptr = NULL;
+    int pool_valid = 0;
+    if (pool_out){
+        memset(pool_out, 0, sizeof(*pool_out));
+    }
+    if (tig_fragment_pool_init(&pool_local, (size_t)((v->count<1024)?v->count:1024), 1<<20)==0){
+        pool_ptr = &pool_local;
+        pool_valid = 1;
+    } else {
+        LOGW("fragment havuzu oluşturulamadı, yeniden birleştirme aday araması devre dışı");
+    }
 
     // 1) contiguous → full
     if (is_contiguous(v)){
@@ -105,14 +161,16 @@ tig_extract_result tig_extract(int fd, const tig_tiff_header *h,
         unsigned char *buf = (unsigned char*)malloc((size_t)len);
         if (buf && pread_some(fd, buf, (size_t)len, start)==0){
             if (v->compression==1){
-                char outp[1024]; snprintf(outp,sizeof(outp), "%s_full_uncomp.tif", base);
+                char outp[1024];
+                build_with_suffix(outp, sizeof(outp), base, "_full_uncomp.tif");
                 if (tig_write_simple_tiff_uncompressed(outp, buf, (size_t)len,
                     v->image_width, v->image_length, v->bits_per_sample,
                     v->samples_per_pixel, v->photometric)==0){
                     R.full_ok=1; R.bytes_full=len;
                 }
             } else {
-                char outp[1024]; snprintf(outp,sizeof(outp), "%s_full.bin", base);
+                char outp[1024];
+                build_with_suffix(outp, sizeof(outp), base, "_full.bin");
                 FILE *f=fopen(outp,"wb"); if(f){ fwrite(buf,1,(size_t)len,f); fclose(f); R.bytes_full=len; }
             }
         }
@@ -129,12 +187,18 @@ tig_extract_result tig_extract(int fd, const tig_tiff_header *h,
         if (!s_tex){
             LOGE("texture score allocation failed for %llu entries", (unsigned long long)v->count);
         }
+        if (pool_valid){
+            tig_fragment_pool_free(pool_ptr);
+        }
         free(s_stream);
         free(s_tex);
         return R;
     }
+    double stream_sum = 0.0, tex_sum = 0.0;
+    uint64_t observed_segments = 0;
     for (uint64_t i=0;i<v->count;i++){
-        char part[1024]; snprintf(part,sizeof(part), "%s_part_%04llu.bin", base, (unsigned long long)i);
+        char part[1024];
+        build_part_filename(part, sizeof(part), base, (unsigned long long)i);
         size_t n = (size_t)v->sizes[i];
         if (n==0 || n>(1u<<30)) continue;
         unsigned char *b = (unsigned char*)malloc(n);
@@ -146,6 +210,36 @@ tig_extract_result tig_extract(int fd, const tig_tiff_header *h,
             else if (v->compression==32773) s_stream[i]=tig_score_packbits(b,n);
             else s_stream[i]=0.5;
             s_tex[i]=0.0; // V3: texture continuity (only for uncompressed path)
+            if (pool_valid){
+                tig_fragment_pool_ingest(pool_ptr, v->offsets[i], b, n, v->compression, s_stream[i], s_tex[i]);
+            }
+            stream_sum += s_stream[i];
+            tex_sum += s_tex[i];
+            observed_segments++;
+        }
+        else {
+            R.missing_parts++;
+            if (pool_valid){
+                tig_fragment_match match;
+                if (tig_fragment_pool_find_candidate(pool_ptr, n, v->compression, 0.55, &match)==0 &&
+                    match.data && match.data_len >= n){
+                    FILE *pf=fopen(part,"wb");
+                    if (pf){ fwrite(match.data,1,n,pf); fclose(pf); R.parts_written++; }
+                    s_stream[i] = match.stream_score;
+                    s_tex[i] = match.texture_score;
+                    stream_sum += s_stream[i];
+                    tex_sum += s_tex[i];
+                    observed_segments++;
+                    LOGW("strip/tile %llu için havuzdan %llu ofsetli aday kullanıldı (skor %.2f)",
+                         (unsigned long long)i,
+                         (unsigned long long)match.offset,
+                         match.match_score);
+                } else {
+                    LOGW("strip/tile %llu (beklenen %zu bayt) okunamadı ve aday bulunamadı", (unsigned long long)i, n);
+                }
+            } else {
+                LOGW("strip/tile %llu (beklenen %zu bayt) okunamadı", (unsigned long long)i, n);
+            }
         }
         free(b);
     }
@@ -154,7 +248,8 @@ tig_extract_result tig_extract(int fd, const tig_tiff_header *h,
     if (!is_contiguous(v) && v->count>1){
         uint32_t *order=0, m=0;
         if (tig_reassemble_order(v->offsets, v->sizes, (uint32_t)v->count, s_stream, s_tex, &order, &m)==0 && order){
-            char cand[1024]; snprintf(cand,sizeof(cand), "%s_candidate.bin", base);
+            char cand[1024];
+            build_with_suffix(cand, sizeof(cand), base, "_candidate.bin");
             FILE *cf=fopen(cand,"wb");
             if (cf){
                 for (uint32_t k=0;k<m;k++){
@@ -171,6 +266,38 @@ tig_extract_result tig_extract(int fd, const tig_tiff_header *h,
         }
     }
 
+    tig_validation_summary summary_local;
+    tig_validation_summary *summary_ptr = NULL;
+    if (summary_out){
+        memset(summary_out, 0, sizeof(*summary_out));
+        summary_ptr = summary_out;
+    } else {
+        summary_ptr = &summary_local;
+    }
+    tig_validation_summarize(v, pool_valid?pool_ptr:NULL, s_stream, s_tex, v->count, R.missing_parts, summary_ptr);
+    if (observed_segments>0){
+        R.score_stream = stream_sum / (double)observed_segments;
+        R.score_texture = tex_sum / (double)observed_segments;
+    } else {
+        R.score_stream = summary_ptr->stream_avg;
+        R.score_texture = summary_ptr->texture_avg;
+    }
+    R.confidence = summary_ptr->confidence;
+
+    if (pool_out && pool_valid){
+        *pool_out = *pool_ptr;
+        // lokali boşalt ki caller free etsin
+        pool_ptr->items = NULL;
+        pool_ptr->count = 0;
+        pool_ptr->capacity = 0;
+        pool_ptr->capture_limit = 0;
+    }
+    if (summary_out){
+        // summary already stored in summary_out
+    }
+    if (pool_valid){
+        tig_fragment_pool_free(pool_ptr);
+    }
     free(s_stream); free(s_tex);
     return R;
 }
@@ -203,13 +330,16 @@ int tig_engine_scan_recover(const char *img_path, const char *out_dir,
         char stem[128]; snprintf(stem,sizeof(stem), "hit_%04llu", (unsigned long long)hits);
         tig_tiff_ifd ifd;
         if (tig_parse_ifd(fd, &hdr, &ifd)==0){
-            tig_extract_result r = tig_extract(fd, &hdr, &ifd, out_dir, stem);
+            tig_fragment_pool pool = {0};
+            tig_validation_summary summary = {0};
+            tig_extract_result r = tig_extract(fd, &hdr, &ifd, out_dir, stem, &pool, &summary);
             // If we got a contiguous uncompressed TIFF full_ok, try to ensure .tif extension
             if (r.full_ok){
                 // the extractor already wrote a file named <stem>_full_uncomp.tif when possible
                 LOGI("recovered full TIFF for %s", stem);
             }
-            tig_write_report(out_dir, stem, &hdr, &ifd, &r);
+            tig_write_report(out_dir, stem, &hdr, &ifd, &r, &pool, &summary);
+            tig_fragment_pool_free(&pool);
             tig_free_ifd(&ifd);
         }
         hits++;
@@ -239,8 +369,11 @@ int tig_engine_dig_range(const char *img_path, tig_range range,
         char stem[128]; snprintf(stem,sizeof(stem), "range_hit_%04llu", (unsigned long long)idx++);
         tig_tiff_ifd ifd;
         if (tig_parse_ifd(fd, &hdr, &ifd)==0){
-            tig_extract_result r = tig_extract(fd, &hdr, &ifd, out_dir, stem);
-            tig_write_report(out_dir, stem, &hdr, &ifd, &r);
+            tig_fragment_pool pool = {0};
+            tig_validation_summary summary = {0};
+            tig_extract_result r = tig_extract(fd, &hdr, &ifd, out_dir, stem, &pool, &summary);
+            tig_write_report(out_dir, stem, &hdr, &ifd, &r, &pool, &summary);
+            tig_fragment_pool_free(&pool);
             tig_free_ifd(&ifd);
         }
     }

--- a/src/core/fragment.c
+++ b/src/core/fragment.c
@@ -1,0 +1,185 @@
+#include "tigre.h"
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+static uint64_t fnv1a64(const unsigned char *buf, size_t len){
+    const uint64_t FNV_OFFSET = 0xcbf29ce484222325ULL;
+    const uint64_t FNV_PRIME  = 0x100000001b3ULL;
+    uint64_t h = FNV_OFFSET;
+    for (size_t i=0;i<len;i++){
+        h ^= (uint64_t)buf[i];
+        h *= FNV_PRIME;
+    }
+    return h;
+}
+
+static double clamp01(double x){
+    if (x < 0.0) return 0.0;
+    if (x > 1.0) return 1.0;
+    return x;
+}
+
+static double entropy_estimate(const unsigned char *buf, size_t len){
+    if (!buf || len == 0) return 0.0;
+    double hist[256];
+    for (int i=0;i<256;i++) hist[i]=0.0;
+    for (size_t i=0;i<len;i++) hist[buf[i]] += 1.0;
+    double inv = 1.0 / (double)len;
+    double ent = 0.0;
+    for (int i=0;i<256;i++){
+        if (hist[i] <= 0.0) continue;
+        double p = hist[i] * inv;
+        ent -= p * (log(p) / log(2.0));
+    }
+    return clamp01(ent / 8.0);
+}
+
+static double header_score(uint16_t compression, const unsigned char *buf, size_t len){
+    if (!buf || len < 4) return 0.0;
+    switch (compression){
+        case 1: // Uncompressed
+            return 0.5; // nötr
+        case 5: // LZW
+            return 0.5 + 0.3 * entropy_estimate(buf, len);
+        case 7: // JPEG baseline
+        case 99:
+            if (len >= 2 && buf[0]==0xFF && buf[1]==0xD8) return 0.9;
+            return 0.2;
+        case 8: // Deflate
+            if ((buf[0] == 0x78 && (buf[1] == 0x9C || buf[1] == 0xDA)) ||
+                (buf[0] == 0x08 && buf[1] == 0x1D)){
+                return 0.8;
+            }
+            return 0.4;
+        case 32773: // PackBits
+            return 0.5;
+        default:
+            return 0.3;
+    }
+}
+
+static int ensure_capacity(tig_fragment_pool *pool, size_t need){
+    if (pool->capacity >= need) return 0;
+    size_t new_cap = pool->capacity ? pool->capacity : 8;
+    while (new_cap < need){
+        new_cap *= 2;
+        if (new_cap < pool->capacity) { // overflow guard
+            new_cap = need;
+            break;
+        }
+    }
+    tig_fragment_entry *tmp = (tig_fragment_entry*)realloc(pool->items, new_cap * sizeof(tig_fragment_entry));
+    if (!tmp) return -1;
+    // yeni alanı temizle
+    for (size_t i=pool->capacity;i<new_cap;i++){
+        memset(&tmp[i], 0, sizeof(tig_fragment_entry));
+    }
+    pool->items = tmp;
+    pool->capacity = new_cap;
+    return 0;
+}
+
+int tig_fragment_pool_init(tig_fragment_pool *pool, size_t capacity_hint, size_t capture_limit){
+    if (!pool) return -1;
+    memset(pool, 0, sizeof(*pool));
+    pool->capture_limit = capture_limit ? capture_limit : (size_t)(1<<20);
+    size_t init_cap = capacity_hint ? capacity_hint : 8;
+    pool->items = (tig_fragment_entry*)calloc(init_cap, sizeof(tig_fragment_entry));
+    if (!pool->items){
+        pool->capacity = 0;
+        return -1;
+    }
+    pool->capacity = init_cap;
+    return 0;
+}
+
+void tig_fragment_pool_reset(tig_fragment_pool *pool){
+    if (!pool) return;
+    for (size_t i=0;i<pool->count;i++){
+        free(pool->items[i].capture);
+        pool->items[i].capture = NULL;
+        pool->items[i].capture_len = 0;
+    }
+    pool->count = 0;
+}
+
+void tig_fragment_pool_free(tig_fragment_pool *pool){
+    if (!pool) return;
+    tig_fragment_pool_reset(pool);
+    free(pool->items);
+    pool->items = NULL;
+    pool->capacity = 0;
+    pool->capture_limit = 0;
+}
+
+int tig_fragment_pool_ingest(tig_fragment_pool *pool, uint64_t offset,
+                              const unsigned char *buf, size_t len,
+                              uint16_t compression, double stream_score,
+                              double texture_score)
+{
+    if (!pool || !buf || len==0) return -1;
+    if (ensure_capacity(pool, pool->count + 1)!=0) return -2;
+    tig_fragment_entry *ent = &pool->items[pool->count];
+    memset(ent, 0, sizeof(*ent));
+    ent->offset = offset;
+    ent->length = len;
+    ent->compression = compression;
+    ent->hash64 = fnv1a64(buf, len);
+    ent->entropy = entropy_estimate(buf, len);
+    ent->header_score = header_score(compression, buf, len);
+    ent->stream_score = stream_score;
+    ent->texture_score = texture_score;
+    size_t cap = len;
+    if (pool->capture_limit && cap > pool->capture_limit) cap = pool->capture_limit;
+    if (cap>0){
+        ent->capture = (unsigned char*)malloc(cap);
+        if (ent->capture){
+            memcpy(ent->capture, buf, cap);
+            ent->capture_len = cap;
+        }
+    }
+    pool->count++;
+    return 0;
+}
+
+int tig_fragment_pool_find_candidate(const tig_fragment_pool *pool,
+                                      uint64_t desired_len, uint16_t compression,
+                                      double tolerance, tig_fragment_match *out)
+{
+    if (!pool || !out) return -1;
+    memset(out, 0, sizeof(*out));
+    if (pool->count==0 || desired_len==0) return -2;
+    double best=-1.0;
+    const tig_fragment_entry *best_ent=NULL;
+    for (size_t i=0;i<pool->count;i++){
+        const tig_fragment_entry *ent = &pool->items[i];
+        double len_min = (double)(ent->length < desired_len ? ent->length : desired_len);
+        double len_max = (double)(ent->length > desired_len ? ent->length : desired_len);
+        double len_score = len_max>0 ? (len_min / len_max) : 0.0;
+        double comp_score = (ent->compression == compression) ? 1.0 : 0.25;
+        double header = ent->header_score;
+        double stream = ent->stream_score;
+        double texture = ent->texture_score;
+        double entropy = ent->entropy;
+        double combined = 0.35*len_score + 0.20*comp_score + 0.15*header + 0.15*stream + 0.15*entropy;
+        if (texture > 0.0) combined += 0.05*texture;
+        if (combined > best){
+            best = combined;
+            best_ent = ent;
+        }
+    }
+    if (!best_ent || best < tolerance) return -3;
+    out->offset = best_ent->offset;
+    out->length = best_ent->length;
+    out->compression = best_ent->compression;
+    out->hash64 = best_ent->hash64;
+    out->entropy = best_ent->entropy;
+    out->header_score = best_ent->header_score;
+    out->stream_score = best_ent->stream_score;
+    out->texture_score = best_ent->texture_score;
+    out->data = best_ent->capture;
+    out->data_len = best_ent->capture_len;
+    out->match_score = clamp01(best);
+    return 0;
+}

--- a/src/core/report.c
+++ b/src/core/report.c
@@ -3,7 +3,9 @@
 
 int tig_write_report(const char *dir, const char *stem,
                      const tig_tiff_header *h, const tig_tiff_ifd *v,
-                     const tig_extract_result *r)
+                     const tig_extract_result *r,
+                     const tig_fragment_pool *pool,
+                     const tig_validation_summary *summary)
 {
     char p[1024]; snprintf(p,sizeof(p), "%s/%s_report.json", dir, stem);
     FILE *f=fopen(p,"w"); if(!f) return -1;
@@ -21,7 +23,35 @@ int tig_write_report(const char *dir, const char *stem,
     fprintf(f,"  \"segments\": %llu,\n", (unsigned long long)v->count);
     fprintf(f,"  \"full_ok\": %d,\n", r->full_ok);
     fprintf(f,"  \"bytes_written_full\": %llu,\n", (unsigned long long)r->bytes_full);
-    fprintf(f,"  \"parts_written\": %llu\n", (unsigned long long)r->parts_written);
+    fprintf(f,"  \"parts_written\": %llu,\n", (unsigned long long)r->parts_written);
+    fprintf(f,"  \"missing_parts\": %u,\n", r->missing_parts);
+    fprintf(f,"  \"score_stream\": %.4f,\n", r->score_stream);
+    fprintf(f,"  \"score_texture\": %.4f,\n", r->score_texture);
+    fprintf(f,"  \"confidence\": %.4f,\n", r->confidence);
+    if (summary){
+        fprintf(f,"  \"coverage_ratio\": %.4f,\n", summary->coverage_ratio);
+        fprintf(f,"  \"entropy_avg\": %.4f,\n", summary->entropy_avg);
+        fprintf(f,"  \"stream_avg\": %.4f,\n", summary->stream_avg);
+        fprintf(f,"  \"texture_avg\": %.4f,\n", summary->texture_avg);
+        fprintf(f,"  \"segments_indexed\": %u,\n", summary->segments_indexed);
+        fprintf(f,"  \"coverage_ok\": %d,\n", summary->coverage_ok);
+    }
+    fprintf(f,"  \"fragments\": [\n");
+    if (pool && pool->items){
+        for (size_t i=0;i<pool->count;i++){
+            const tig_fragment_entry *ent = &pool->items[i];
+            fprintf(f,"    {\"offset\": %llu, \"length\": %llu, \"compression\": %u, \"entropy\": %.4f, \"header_score\": %.4f, \"stream_score\": %.4f, \"texture_score\": %.4f}%s\n",
+                    (unsigned long long)ent->offset,
+                    (unsigned long long)ent->length,
+                    ent->compression,
+                    ent->entropy,
+                    ent->header_score,
+                    ent->stream_score,
+                    ent->texture_score,
+                    (i+1<pool->count)?",":"");
+        }
+    }
+    fprintf(f,"  ]\n");
     fprintf(f,"}\n");
     fclose(f);
     return 0;

--- a/src/core/validator.c
+++ b/src/core/validator.c
@@ -1,0 +1,84 @@
+#include "tigre.h"
+#include <string.h>
+
+static double clamp01(double x){
+    if (x < 0.0) return 0.0;
+    if (x > 1.0) return 1.0;
+    return x;
+}
+
+int tig_validation_summarize(const tig_tiff_ifd *ifd,
+                              const tig_fragment_pool *pool,
+                              const double *stream_scores,
+                              const double *texture_scores,
+                              uint64_t count,
+                              uint32_t missing_parts,
+                              tig_validation_summary *out_summary)
+{
+    if (!out_summary) return -1;
+    memset(out_summary, 0, sizeof(*out_summary));
+
+    double stream_sum = 0.0, texture_sum = 0.0;
+    uint64_t score_items = 0;
+    if (stream_scores && texture_scores){
+        for (uint64_t i=0;i<count;i++){
+            stream_sum  += stream_scores[i];
+            texture_sum += texture_scores[i];
+            score_items++;
+        }
+    }
+    if (score_items>0){
+        out_summary->stream_avg  = clamp01(stream_sum  / (double)score_items);
+        out_summary->texture_avg = clamp01(texture_sum / (double)score_items);
+    }
+
+    double entropy_sum = 0.0;
+    uint64_t captured_len = 0;
+    uint32_t indexed = 0;
+    if (pool && pool->items){
+        indexed = (uint32_t)pool->count;
+        for (size_t i=0;i<pool->count;i++){
+            const tig_fragment_entry *ent = &pool->items[i];
+            entropy_sum += ent->entropy;
+            if (ent->length < ((uint64_t)1<<62)){
+                captured_len += (uint64_t)ent->length;
+            }
+        }
+    }
+    out_summary->segments_indexed = indexed;
+    if (indexed>0){
+        out_summary->entropy_avg = clamp01(entropy_sum / (double)indexed);
+    }
+
+    double expected_len = 0.0;
+    if (ifd && ifd->sizes){
+        for (uint64_t i=0;i<count && i<ifd->count;i++){
+            expected_len += (double)ifd->sizes[i];
+        }
+    }
+    if (expected_len > 0.0){
+        double cov = (double)captured_len / expected_len;
+        if (cov > 1.0) cov = 1.0;
+        if (cov < 0.0) cov = 0.0;
+        out_summary->coverage_ratio = cov;
+    } else {
+        out_summary->coverage_ratio = 0.0;
+    }
+
+    out_summary->missing_parts = missing_parts;
+    out_summary->coverage_ok = (out_summary->coverage_ratio >= 0.95 && missing_parts == 0);
+
+    double coverage_term = out_summary->coverage_ratio;
+    double stream_term   = out_summary->stream_avg;
+    double texture_term  = out_summary->texture_avg;
+    double entropy_term  = out_summary->entropy_avg;
+
+    double confidence = 0.15 + 0.40*stream_term + 0.25*coverage_term + 0.10*texture_term + 0.10*entropy_term;
+    if (indexed == 0) confidence *= 0.6;
+    if (missing_parts > 0){
+        double penalty = 1.0 / (1.0 + (double)missing_parts);
+        confidence *= penalty;
+    }
+    out_summary->confidence = clamp01(confidence);
+    return 0;
+}

--- a/tests/fragment_pool.c
+++ b/tests/fragment_pool.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+#include <string.h>
+
+#include "tigre.h"
+
+int main(void)
+{
+    tig_fragment_pool pool;
+    assert(tig_fragment_pool_init(&pool, 2, 64) == 0);
+
+    static const unsigned char deflate_data[] = {
+        0x78, 0x9C, 0x63, 0x60, 0x18, 0x05, 0xA3, 0x60
+    };
+    static const unsigned char jpeg_data[] = {
+        0xFF, 0xD8, 0xFF, 0xE0, 0x11, 0x22, 0x33, 0x44
+    };
+
+    assert(tig_fragment_pool_ingest(&pool, 1024, deflate_data, sizeof(deflate_data), 8, 0.8, 0.1) == 0);
+    assert(tig_fragment_pool_ingest(&pool, 4096, jpeg_data, sizeof(jpeg_data), 7, 0.7, 0.2) == 0);
+
+    tig_fragment_match match;
+    assert(tig_fragment_pool_find_candidate(&pool, sizeof(deflate_data), 8, 0.3, &match) == 0);
+    assert(match.offset == 1024);
+    assert(match.match_score >= 0.3);
+    assert(match.data != NULL);
+
+    tig_tiff_ifd ifd;
+    memset(&ifd, 0, sizeof(ifd));
+    static const uint64_t sizes[2] = {sizeof(deflate_data), sizeof(jpeg_data)};
+    ifd.count = 2;
+    ifd.sizes = sizes;
+
+    double stream_scores[2] = {0.8, 0.7};
+    double texture_scores[2] = {0.1, 0.2};
+    tig_validation_summary summary;
+    assert(tig_validation_summarize(&ifd, &pool, stream_scores, texture_scores, 2, 0, &summary) == 0);
+    assert(summary.segments_indexed == 2);
+    assert(summary.confidence > 0.4);
+
+    tig_fragment_pool_free(&pool);
+    return 0;
+}

--- a/tests/oversized_ifd.c
+++ b/tests/oversized_ifd.c
@@ -1,3 +1,6 @@
+#if !defined(_WIN32)
+#define _XOPEN_SOURCE 700
+#endif
 #include <assert.h>
 #include <errno.h>
 #include <stdint.h>
@@ -25,9 +28,11 @@ int tig_write_simple_tiff_uncompressed(const char *path,
 }
 int tig_write_report(const char *dir, const char *stem,
                      const tig_tiff_header *h, const tig_tiff_ifd *v,
-                     const tig_extract_result *r)
+                     const tig_extract_result *r,
+                     const tig_fragment_pool *pool,
+                     const tig_validation_summary *summary)
 {
-    (void)dir; (void)stem; (void)h; (void)v; (void)r;
+    (void)dir; (void)stem; (void)h; (void)v; (void)r; (void)pool; (void)summary;
     return 0;
 }
 int tig_open_ro(const char *path) { (void)path; return -1; }
@@ -43,6 +48,29 @@ int tig_parse_ifd(int fd, const tig_tiff_header *hdr, tig_tiff_ifd *out_ifd)
     return -1;
 }
 void tig_free_ifd(tig_tiff_ifd *v) { (void)v; }
+
+int tig_fragment_pool_init(tig_fragment_pool *pool, size_t capacity_hint, size_t capture_limit)
+{ (void)pool; (void)capacity_hint; (void)capture_limit; return 0; }
+void tig_fragment_pool_reset(tig_fragment_pool *pool) { (void)pool; }
+void tig_fragment_pool_free(tig_fragment_pool *pool) { (void)pool; }
+int tig_fragment_pool_ingest(tig_fragment_pool *pool, uint64_t offset,
+                              const unsigned char *buf, size_t len,
+                              uint16_t compression, double stream_score,
+                              double texture_score)
+{ (void)pool; (void)offset; (void)buf; (void)len; (void)compression; (void)stream_score; (void)texture_score; return 0; }
+int tig_fragment_pool_find_candidate(const tig_fragment_pool *pool,
+                                      uint64_t desired_len, uint16_t compression,
+                                      double tolerance, tig_fragment_match *out)
+{ (void)pool; (void)desired_len; (void)compression; (void)tolerance; (void)out; return -1; }
+
+int tig_validation_summarize(const tig_tiff_ifd *ifd,
+                              const tig_fragment_pool *pool,
+                              const double *stream_scores,
+                              const double *texture_scores,
+                              uint64_t count,
+                              uint32_t missing_parts,
+                              tig_validation_summary *out_summary)
+{ (void)ifd; (void)pool; (void)stream_scores; (void)texture_scores; (void)count; (void)missing_parts; (void)out_summary; return 0; }
 
 // Pull in the implementation under test.
 #include "../src/core/engine.c"
@@ -68,7 +96,7 @@ int main(void)
     ifd.sizes = sizes;
 
     errno = 0;
-    tig_extract_result r = tig_extract(-1, &hdr, &ifd, ".", "oversized_ifd");
+    tig_extract_result r = tig_extract(-1, &hdr, &ifd, ".", "oversized_ifd", NULL, NULL);
 
     assert(r.full_ok == 0);
     assert(r.parts_written == 0);


### PR DESCRIPTION
## Summary
- expand the public API to expose fragment pool, validation summary, and confidence data during TIFF extraction
- implement fragment pooling and validation helpers to score segments, power heuristic recovery, and enrich JSON reports with fragment metadata
- add dedicated tests covering fragment indexing heuristics and update the oversized IFD regression harness for the new interfaces

## Testing
- make -f Makefile.linux
- gcc -std=c11 -Wall -Wextra -Iinclude -Isrc tests/oversized_ifd.c -o tests/oversized_ifd
- ./tests/oversized_ifd
- gcc -std=c11 -Wall -Wextra -Iinclude -Isrc tests/fragment_pool.c src/core/fragment.c src/core/validator.c -o tests/fragment_pool -lm
- ./tests/fragment_pool

------
https://chatgpt.com/codex/tasks/task_e_68d42bb33a6c8330ab586cb06d304342