### PR TITLE
Handle oversized TIFF arrays safely

### DIFF
--- a/src/carve/tiff_ifd.c
+++ b/src/carve/tiff_ifd.c
@@ -8,6 +8,9 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <errno.h>
+#include <stdint.h>
+#include <limits.h>
 
 static int pread_all(int fd, void *buf, size_t n, uint64_t off);
 
@@ -24,15 +27,31 @@ static inline uint64_t U64(const unsigned char*p,int le){
 static int read_array64(int fd, int big, int le, int type, uint64_t count, uint64_t val_or_off,
                         uint64_t base, uint64_t **out)
 {
+    if (out) *out = NULL;
+    if (count == 0) return 0;
     // normalize to 64-bit array
     size_t el = (type==3?2 : type==4?4 : 8);
+    if (count > SIZE_MAX / el || count > SIZE_MAX / sizeof(uint64_t)){
+        errno = ENOMEM;
+        return -5;
+    }
     size_t total = (size_t)(count * el);
     unsigned char *tmp = malloc(total);
-    if (!tmp) return -1;
-    uint64_t abs = big ? val_or_off : (base + val_or_off);
+    if (!tmp){ errno = ENOMEM; return -1; }
+    uint64_t abs;
+    if (big){
+        abs = val_or_off;
+    } else {
+        if (val_or_off > UINT64_MAX - base){
+            free(tmp);
+            errno = EOVERFLOW;
+            return -4;
+        }
+        abs = base + val_or_off;
+    }
     if (pread_all(fd, tmp, total, abs)!=0){ free(tmp); return -2; }
     uint64_t *a = (uint64_t*)malloc(sizeof(uint64_t)*count);
-    if (!a){ free(tmp); return -3; }
+    if (!a){ free(tmp); errno = ENOMEM; return -3; }
     for (uint64_t i=0;i<count;i++){
         const unsigned char *p = tmp + i*el;
         if (el==2) a[i] = (uint64_t)U16(p, le);
@@ -62,6 +81,7 @@ int tig_parse_ifd(int fd, const tig_tiff_header *hdr, tig_tiff_ifd *out){
     uint64_t *tile_offs=0,*tile_sz=0, tc=0;
     uint64_t rows_per_strip=0, tile_w=0, tile_h=0;
     uint64_t iw=0, ih=0; uint16_t bps=0,spp=0,comp=1,photo=0,planar=1,predict=1;
+    int rc_error = 0;
 
     for (uint64_t i=0;i<n;i++){
         unsigned char *e = ents + i*esz;
@@ -135,16 +155,30 @@ int tig_parse_ifd(int fd, const tig_tiff_header *hdr, tig_tiff_ifd *out){
                 uint64_t *tmp=0; if (read_array64(fd, hdr->is_big_tiff, hdr->is_le, typ, 1, val, base, &tmp)==0){ tile_h=tmp[0]; free(tmp); }
             } break;
             case 273: { // StripOffsets
-                sc = cnt; read_array64(fd, hdr->is_big_tiff, hdr->is_le, typ, cnt, val, base, &strip_offs);
+                uint64_t *tmp = NULL;
+                int rc = read_array64(fd, hdr->is_big_tiff, hdr->is_le, typ, cnt, val, base, &tmp);
+                if (rc!=0){ rc_error = rc; goto fail; }
+                strip_offs = tmp;
+                sc = cnt;
             } break;
             case 279: { // StripByteCounts
-                read_array64(fd, hdr->is_big_tiff, hdr->is_le, typ, cnt, val, base, &strip_sz);
+                uint64_t *tmp = NULL;
+                int rc = read_array64(fd, hdr->is_big_tiff, hdr->is_le, typ, cnt, val, base, &tmp);
+                if (rc!=0){ rc_error = rc; goto fail; }
+                strip_sz = tmp;
             } break;
             case 324: { // TileOffsets
-                tc = cnt; read_array64(fd, hdr->is_big_tiff, hdr->is_le, typ, cnt, val, base, &tile_offs);
+                uint64_t *tmp = NULL;
+                int rc = read_array64(fd, hdr->is_big_tiff, hdr->is_le, typ, cnt, val, base, &tmp);
+                if (rc!=0){ rc_error = rc; goto fail; }
+                tile_offs = tmp;
+                tc = cnt;
             } break;
             case 325: { // TileByteCounts
-                read_array64(fd, hdr->is_big_tiff, hdr->is_le, typ, cnt, val, base, &tile_sz);
+                uint64_t *tmp = NULL;
+                int rc = read_array64(fd, hdr->is_big_tiff, hdr->is_le, typ, cnt, val, base, &tmp);
+                if (rc!=0){ rc_error = rc; goto fail; }
+                tile_sz = tmp;
             } break;
             default: break;
         }
@@ -172,6 +206,14 @@ int tig_parse_ifd(int fd, const tig_tiff_header *hdr, tig_tiff_ifd *out){
         return -4;
     }
     return 0;
+
+fail:
+    free(ents);
+    if (strip_offs) free(strip_offs);
+    if (strip_sz) free(strip_sz);
+    if (tile_offs) free(tile_offs);
+    if (tile_sz) free(tile_sz);
+    return rc_error ? rc_error : -5;
 }
 
 void tig_free_ifd(tig_tiff_ifd *v){

--- a/tests/tiff_ifd_overflow.c
+++ b/tests/tiff_ifd_overflow.c
@@ -1,0 +1,69 @@
+#if !defined(_WIN32)
+#define _XOPEN_SOURCE 700
+#endif
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "tigre.h"
+
+static void put_u16_le(unsigned char *p, uint16_t v){
+    p[0] = (unsigned char)(v & 0xFF);
+    p[1] = (unsigned char)((v >> 8) & 0xFF);
+}
+
+static void put_u64_le(unsigned char *p, uint64_t v){
+    for (int i=0;i<8;i++){
+        p[i] = (unsigned char)((v >> (8*i)) & 0xFF);
+    }
+}
+
+int main(void){
+    char tmpl[] = "ifd_overflowXXXXXX";
+    int fd = mkstemp(tmpl);
+    assert(fd >= 0);
+    unlink(tmpl);
+
+    unsigned char count_buf[8];
+    put_u64_le(count_buf, 2);
+    assert(pwrite(fd, count_buf, sizeof(count_buf), 0) == (ssize_t)sizeof(count_buf));
+
+    unsigned char entries[40];
+    memset(entries, 0, sizeof(entries));
+
+    uint64_t huge_count = (UINT64_MAX / 8ULL) + 1ULL;
+
+    put_u16_le(entries + 0, 273);      // StripOffsets tag
+    put_u16_le(entries + 2, 16);       // LONG8 type
+    put_u64_le(entries + 4, huge_count);
+    put_u64_le(entries + 12, 0);       // value/offset (unused in this test)
+
+    put_u16_le(entries + 20, 279);     // StripByteCounts tag
+    put_u16_le(entries + 22, 16);
+    put_u64_le(entries + 24, 1);
+    put_u64_le(entries + 32, 0);
+
+    assert(pwrite(fd, entries, sizeof(entries), 8) == (ssize_t)sizeof(entries));
+
+    tig_tiff_header hdr;
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.is_big_tiff = 1;
+    hdr.is_le = 1;
+    hdr.hdr_off = 0;
+    hdr.first_ifd = 0;
+
+    tig_tiff_ifd ifd;
+    errno = 0;
+    int rc = tig_parse_ifd(fd, &hdr, &ifd);
+    assert(rc != 0);
+    assert(errno == ENOMEM);
+
+    close(fd);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- guard TIFF array parsing against integer overflow and impossible offset calculations, surfacing ENOMEM/EOVERFLOW instead of crashing
- stop parsing when strip/tile tables fail to load and ensure allocations are freed on failure paths
- add a regression test that feeds an oversized StripOffsets count to tig_parse_ifd to confirm the guard works

## Testing
- `gcc -std=c11 -Wall -Wextra -Iinclude -Isrc -D_FILE_OFFSET_BITS=64 tests/fragment_pool.c src/core/fragment.c src/core/validator.c -lm -o tests/bin_fragment_pool`
- `gcc -std=c11 -Wall -Wextra -Iinclude -Isrc -D_FILE_OFFSET_BITS=64 tests/oversized_ifd.c -o tests/bin_oversized_ifd`
- `gcc -std=c11 -Wall -Wextra -Iinclude -Isrc -D_FILE_OFFSET_BITS=64 tests/tiff_ifd_overflow.c src/carve/tiff_ifd.c -o tests/bin_tiff_ifd_overflow`
- `tests/bin_fragment_pool`
- `tests/bin_oversized_ifd`
- `tests/bin_tiff_ifd_overflow`


------
https://chatgpt.com/codex/tasks/task_e_68d50097fdc08330864082800d7e920b